### PR TITLE
benchmarker with configfile for machine dependent paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,11 @@ tmp_*/
 .dacecache*
 .gt4py_cache/
 
+# docs
 knowledgeDB/site
+
+# benchmarker
+benchmarker/.config.yaml
 
 # Fortran-ism
 *.mod

--- a/benchmarker/.config-example.yaml
+++ b/benchmarker/.config-example.yaml
@@ -1,0 +1,10 @@
+# copy this file to `.config.yaml` and edit the paths as necessary
+
+paths:
+  namelist: "/path/to/c12_6ranks_standard/dycore/input.nml"
+  c12_AI2:
+    data: "/path/to/c12_6ranks_standard/dycore/D_SW-In.nc"
+    eta_file: "/path/to/eta79.nc"
+  c24_GEOS:
+    data: "/path/to/dynamics_C24L72_1x1/D_SW-In.nc"
+    eta_ak_bk_file: "/path/to/dynamics_C24L72_1x1/Ak_Bk.nc"

--- a/benchmarker/setup_cube_sphere.py
+++ b/benchmarker/setup_cube_sphere.py
@@ -23,7 +23,7 @@ def setup_fv_cube_grid(
     backend: str,
     eta_file: str | None,
     eta_ak_bk_file: str | None,
-    orchestrate: DaCeOrchestration,
+    orchestrate: DaCeOrchestration | None,
 ):
     """
 
@@ -85,13 +85,14 @@ def setup_fv_cube_grid(
     # Build a DaCeConfig for orchestration.
     # This and all orchestration code are transparent when outside
     # configuration deactivate orchestration
-    stencil_config.dace_config = DaceConfig(
-        communicator=communicator,
-        backend=stencil_config.backend,
-        tile_nx=tile_shape[0],
-        tile_nz=tile_shape[1],
-        orchestration=orchestrate,
-    )
+    if orchestrate is not None:
+        stencil_config.dace_config = DaceConfig(
+            communicator=communicator,
+            backend=stencil_config.backend,
+            tile_nx=tile_shape[0],
+            tile_nz=tile_shape[1],
+            orchestration=orchestrate,
+        )
 
     grid_indexing = GridIndexing.from_sizer_and_communicator(
         sizer=_sizer, comm=communicator


### PR DESCRIPTION
Making an exceptional PR to coordinate this. What do you guys think?

- minimal config file for machine dependent paths
- update `pyFV3` -> `pyfv3` name change
- and when I was running `gt:cpu_ifrist`, I didn't know what else (than `None`) to specify for `ORCHESTRATION`

with that, the road towards a `click`-based little cli tool is kind of straight forward (where most of the CAPSLOCK VARS will just become options).

feel free to merge over night if we don't need to discuss anything.